### PR TITLE
Slots support for multisite feature

### DIFF
--- a/docs/dynamic_configuration.rst
+++ b/docs/dynamic_configuration.rst
@@ -68,7 +68,11 @@ In order to change the dynamic configuration you can use either :ref:`patronictl
 
 -  **sites**: generate permanent replication slots for multisite operation. If dynamic configuration has a slot definition for current site then replication connection to primary site will be done using a replication slot. On the primary site permanent physical slots will be created on all nodes for all other sites. Sites that are not defined in this section will operate without replication slots.
 
-   -  **my\_site\_name**: Name of the site. Corresponds to site name defined in multisite section.
+   -  **my\_site\_name**: Name of this site. Corresponds to site name defined in multisite section.
+
+      - **slot**: Name of the permanent replication slot to use for this site.
+
+   -  **other\_site\_name**: Name of another site. Corresponds to site name defined in multisite section.
 
       - **slot**: Name of the permanent replication slot to use for this site.
 

--- a/docs/dynamic_configuration.rst
+++ b/docs/dynamic_configuration.rst
@@ -66,6 +66,12 @@ In order to change the dynamic configuration you can use either :ref:`patronictl
       -  **plugin**: the plugin name for the logical slot.
       -  **cluster_type**: the type of cluster (``primary`` or ``standby``) the slot should only be created on, otherwise it will not be created or an already existing slot will be dropped.
 
+-  **sites**: generate permanent replication slots for multisite operation. If dynamic configuration has a slot definition for current site then replication connection to primary site will be done using a replication slot. On the primary site permanent physical slots will be created on all nodes for all other sites. Sites that are not defined in this section will operate without replication slots.
+
+   -  **my\_site\_name**: Name of the site. Corresponds to site name defined in multisite section.
+
+      - **slot**: Name of the permanent replication slot to use for this site.
+
 -  **ignore\_slots**: list of sets of replication slot properties for which Patroni should ignore matching slots. This configuration/feature/etc. is useful when some replication slots are managed outside of Patroni. Any subset of matching properties will cause a slot to be ignored.
 
    -  **name**: the name of the replication slot.

--- a/patroni/dcs/__init__.py
+++ b/patroni/dcs/__init__.py
@@ -1168,12 +1168,16 @@ class Cluster(NamedTuple('Cluster',
         if not global_config.use_slots or tags.nofailover:
             return {}
 
-        if global_config.is_standby_cluster or self.get_slot_name_on_primary(postgresql.name, tags) is None:
-            return self.permanent_physical_slots\
-                if postgresql.can_advance_slots or role == PostgresqlRole.STANDBY_LEADER else {}
+        site_slots: Dict[str, Any] = self._get_site_slots(tags, role)
 
-        return self.__permanent_slots if postgresql.can_advance_slots or role == PostgresqlRole.PRIMARY \
-            else self.__permanent_logical_slots
+        if global_config.is_standby_cluster or self.get_slot_name_on_primary(postgresql.name, tags) is None:
+            configured_slots = self.permanent_physical_slots\
+                if postgresql.can_advance_slots or role == PostgresqlRole.STANDBY_LEADER else {}
+        else:
+            configured_slots = self.__permanent_slots if postgresql.can_advance_slots or role == PostgresqlRole.PRIMARY \
+                else self.__permanent_logical_slots
+
+        return {**site_slots, **configured_slots}
 
     def _get_members_slots(self, name: str, role: 'PostgresqlRole', nofailover: bool,
                            can_advance_slots: bool) -> Dict[str, Dict[str, Any]]:
@@ -1279,6 +1283,35 @@ class Cluster(NamedTuple('Cluster',
                                    for k, v in slot_conflicts.items() if len(v) > 1))
         return ret
 
+    def _get_site_slots(self, member: Tags, role: 'PostgresqlRole') -> Dict[str, Dict[str, Any]]:
+        # FIXME: Breaking through abstractions to get at multisite status. Should be refactored.
+        if member.__class__.__name__ != 'Patroni':
+            return {}
+
+        multisite = member.multisite
+        if not global_config.use_slots or not multisite.is_active:
+            return {}
+
+        # TODO: add a mechanism to sync slots across sites
+        if multisite.is_follower:
+            return {}
+
+        from ..postgresql.misc import PostgresqlRole
+
+        slots = {}
+        for site, site_config in global_config.sites.items():
+            if site == multisite.name:
+                # Only create slots for other sites
+                continue
+            if 'slot' in site_config:
+                slot_name = site_config['slot']
+                slots[slot_name] = {
+                    'type': 'physical',
+                    'lsn': self.slots.get(slot_name, 0),
+                    'expected_active': role in (PostgresqlRole.PRIMARY, PostgresqlRole.STANDBY_LEADER),
+                }
+        return slots
+
     def has_permanent_slots(self, postgresql: 'Postgresql', member: Tags) -> bool:
         """Check if our node has permanent replication slots configured.
 
@@ -1298,7 +1331,7 @@ class Cluster(NamedTuple('Cluster',
         self._merge_permanent_slots(slots, permanent_slots, postgresql.name, role, postgresql.can_advance_slots)
         return len(slots) > len(members_slots) or any(self.is_physical_slot(v) for v in permanent_slots.values())
 
-    def maybe_filter_permanent_slots(self, postgresql: 'Postgresql', slots: Dict[str, int]) -> Dict[str, int]:
+    def maybe_filter_permanent_slots(self, postgresql: 'Postgresql', slots: Dict[str, int], member: Tags) -> Dict[str, int]:
         """Filter out all non-permanent slots from provided *slots* dict.
 
         .. note::
@@ -1308,6 +1341,7 @@ class Cluster(NamedTuple('Cluster',
 
         :param postgresql: reference to :class:`Postgresql` object.
         :param slots: slot names with LSN values.
+        :param member: reference to an object implementing :class:`Tags` interface
         :returns: a :class:`dict` object that contains only slots that are known to be permanent.
         """
         from ..postgresql.misc import PostgresqlRole
@@ -1315,8 +1349,7 @@ class Cluster(NamedTuple('Cluster',
         if global_config.member_slots_ttl > 0:
             return slots
 
-        permanent_slots: Dict[str, Any] = self._get_permanent_slots(postgresql, RemoteMember('', {}),
-                                                                    PostgresqlRole.REPLICA)
+        permanent_slots: Dict[str, Any] = self._get_permanent_slots(postgresql, member, PostgresqlRole.REPLICA)
         members_slots = {slot_name_from_member_name(m.name) for m in self.members}
 
         return {name: value for name, value in slots.items() if name in permanent_slots

--- a/patroni/dcs/__init__.py
+++ b/patroni/dcs/__init__.py
@@ -23,12 +23,12 @@ from ..tags import Tags
 from ..utils import deep_compare, parse_int, uri
 
 if TYPE_CHECKING:  # pragma: no cover
+    from ..__main__ import Patroni
     from ..config import Config
     from ..multisite import MultisiteController
     from ..postgresql import Postgresql
     from ..postgresql.misc import PostgresqlRole
     from ..postgresql.mpp import AbstractMPP
-    from ..__main__ import Patroni
 
 slot_name_re = re.compile('^[a-z0-9_]{1,63}$')
 logger = logging.getLogger(__name__)

--- a/patroni/dcs/__init__.py
+++ b/patroni/dcs/__init__.py
@@ -24,9 +24,11 @@ from ..utils import deep_compare, parse_int, uri
 
 if TYPE_CHECKING:  # pragma: no cover
     from ..config import Config
+    from ..multisite import MultisiteController
     from ..postgresql import Postgresql
     from ..postgresql.misc import PostgresqlRole
     from ..postgresql.mpp import AbstractMPP
+    from ..__main__ import Patroni
 
 slot_name_re = re.compile('^[a-z0-9_]{1,63}$')
 logger = logging.getLogger(__name__)
@@ -1288,7 +1290,7 @@ class Cluster(NamedTuple('Cluster',
         if member.__class__.__name__ != 'Patroni':
             return {}
 
-        multisite = member.multisite
+        multisite: MultisiteController = cast('MultisiteController', cast('Patroni', member).multisite)
         if not global_config.use_slots or not multisite.is_active:
             return {}
 
@@ -1298,7 +1300,7 @@ class Cluster(NamedTuple('Cluster',
 
         from ..postgresql.misc import PostgresqlRole
 
-        slots = {}
+        slots: Dict[str, Dict[str, Any]] = {}
         for site, site_config in global_config.sites.items():
             if site == multisite.name:
                 # Only create slots for other sites

--- a/patroni/dcs/__init__.py
+++ b/patroni/dcs/__init__.py
@@ -1173,13 +1173,13 @@ class Cluster(NamedTuple('Cluster',
         site_slots: Dict[str, Any] = self._get_site_slots(tags, role)
 
         if global_config.is_standby_cluster or self.get_slot_name_on_primary(postgresql.name, tags) is None:
-            configured_slots = self.permanent_physical_slots\
+            config_slots = self.permanent_physical_slots\
                 if postgresql.can_advance_slots or role == PostgresqlRole.STANDBY_LEADER else {}
         else:
-            configured_slots = self.__permanent_slots if postgresql.can_advance_slots or role == PostgresqlRole.PRIMARY \
+            config_slots = self.__permanent_slots if postgresql.can_advance_slots or role == PostgresqlRole.PRIMARY \
                 else self.__permanent_logical_slots
 
-        return {**site_slots, **configured_slots}
+        return {**site_slots, **config_slots}
 
     def _get_members_slots(self, name: str, role: 'PostgresqlRole', nofailover: bool,
                            can_advance_slots: bool) -> Dict[str, Dict[str, Any]]:
@@ -1333,7 +1333,8 @@ class Cluster(NamedTuple('Cluster',
         self._merge_permanent_slots(slots, permanent_slots, postgresql.name, role, postgresql.can_advance_slots)
         return len(slots) > len(members_slots) or any(self.is_physical_slot(v) for v in permanent_slots.values())
 
-    def maybe_filter_permanent_slots(self, postgresql: 'Postgresql', slots: Dict[str, int], member: Tags) -> Dict[str, int]:
+    def maybe_filter_permanent_slots(self, postgresql: 'Postgresql', slots: Dict[str, int],
+                                     member: Tags) -> Dict[str, int]:
         """Filter out all non-permanent slots from provided *slots* dict.
 
         .. note::

--- a/patroni/global_config.py
+++ b/patroni/global_config.py
@@ -241,5 +241,9 @@ class GlobalConfig(types.ModuleType):
         """
         return self.get_int('member_slots_ttl', 1800, base_unit='s')
 
+    @property
+    def sites(self) -> Dict[str, Dict[str, Any]]:
+        """Currently configured value of ``sites`` from the global configuration."""
+        return deepcopy(self.get('sites') or EMPTY_DICT.copy())
 
 sys.modules[__name__] = GlobalConfig()

--- a/patroni/global_config.py
+++ b/patroni/global_config.py
@@ -246,4 +246,5 @@ class GlobalConfig(types.ModuleType):
         """Currently configured value of ``sites`` from the global configuration."""
         return deepcopy(self.get('sites') or EMPTY_DICT.copy())
 
+
 sys.modules[__name__] = GlobalConfig()

--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -395,7 +395,8 @@ class Ha(object):
         if update_status:
             try:
                 last_lsn = self._last_wal_lsn = self.state_handler.last_operation()
-                slots = self.cluster.maybe_filter_permanent_slots(self.state_handler, self.state_handler.slots(), self.patroni)
+                slots = self.cluster.maybe_filter_permanent_slots(self.state_handler, self.state_handler.slots(),
+                                                                  self.patroni)
             except Exception:
                 logger.exception('Exception when called state_handler.last_operation()')
         try:

--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -395,7 +395,7 @@ class Ha(object):
         if update_status:
             try:
                 last_lsn = self._last_wal_lsn = self.state_handler.last_operation()
-                slots = self.cluster.maybe_filter_permanent_slots(self.state_handler, self.state_handler.slots())
+                slots = self.cluster.maybe_filter_permanent_slots(self.state_handler, self.state_handler.slots(), self.patroni)
             except Exception:
                 logger.exception('Exception when called state_handler.last_operation()')
         try:

--- a/patroni/multisite.py
+++ b/patroni/multisite.py
@@ -14,6 +14,7 @@ import kubernetes
 from .dcs import AbstractDCS, Cluster, Member
 from .dcs.kubernetes import catch_kubernetes_errors
 from .exceptions import DCSError
+from . import global_config
 
 if TYPE_CHECKING:  # pragma: no cover
     from .config import Config
@@ -178,19 +179,35 @@ class MultisiteController(Thread, AbstractSiteController):
         # TODO: check if we replicated everything to standby site
         self.release()
 
+    @property
+    def _replication_slot(self) -> Optional[str]:
+        site_config = global_config.sites.get(self.name)
+        return site_config and site_config.get('slot')
+
     def _disconnected_operation(self):
         self._standby_config = {'restore_command': 'false'}
+
+    @property
+    def is_follower(self):
+        """Returns true if this site is following another site"""
+        cfg = self._standby_config  # Fetch once for atomic access
+        return cfg is not None and 'host' in cfg
 
     def _set_standby_config(self, other: Member):
         logger.info(f"Multisite replicate from {other}")
         # TODO: add support for replication slots
         try:
-            old_conf, self._standby_config = self._standby_config, {
+
+            new_config = {
                 'host': other.data['host'],
                 'port': other.data['port'],
                 'create_replica_methods': ['basebackup'],
                 'leader_site': other.name,
             }
+            slot = self._replication_slot
+            if slot:
+                new_config['primary_slot_name'] = slot
+            old_conf, self._standby_config = self._standby_config, new_config
         except KeyError:
             old_conf = self._standby_config
             self._disconnected_operation()
@@ -304,8 +321,7 @@ class MultisiteController(Thread, AbstractSiteController):
 
     def _observe_leader(self):
         """
-        Observe multisite state and make sure
-
+        Observe multisite state and make sure standby_cluster setting gets updated
         """
         try:
             cluster = self.dcs.get_cluster()

--- a/patroni/multisite.py
+++ b/patroni/multisite.py
@@ -373,7 +373,7 @@ class MultisiteController(Thread, AbstractSiteController):
                         return
                 else:
                     history_state = cluster.history.lines[-1]
-                    if isinstance(history_state, (list, tuple)) and len(history_state) > 3:  # pyright: ignore[reportUnnecessaryIsInstance]
+                    if isinstance(history_state, (list, tuple)) and len(history_state) > 3:  # noqa: E501 # pyright: ignore[reportUnnecessaryIsInstance]
                         if history_state[3] != self.name:
                             new_state = (history_state[0] + 1, 0, '', self.name)
                             self.dcs.set_history_value(json.dumps(cluster.history.lines + [new_state]))

--- a/patroni/multisite.py
+++ b/patroni/multisite.py
@@ -11,10 +11,10 @@ import six
 
 import kubernetes
 
+from . import global_config
 from .dcs import AbstractDCS, Cluster, Member
 from .dcs.kubernetes import catch_kubernetes_errors
 from .exceptions import DCSError
-from . import global_config
 
 if TYPE_CHECKING:  # pragma: no cover
     from .config import Config

--- a/patroni/multisite.py
+++ b/patroni/multisite.py
@@ -369,14 +369,17 @@ class MultisiteController(Thread, AbstractSiteController):
                     history_state = cluster.history.lines[0]
                     if history_state.get('last_leader') != self.name:  # pyright: ignore [reportUnknownMemberType]
                         new_state = (history_state.get('switches', 0) + 1, 0, '', self.name)  # noqa: E501 # pyright: ignore [reportUnknownMemberType, reportUnknownVariableType]
-                        self.dcs.set_history_value(json.dumps(new_state))  # FIXME: append instead
+                        self.dcs.set_history_value(json.dumps([new_state]))
+                        return
                 else:
                     history_state = cluster.history.lines[-1]
-                    if len(history_state) > 3 and history_state[3] != self.name:
-                        new_state = (history_state[0] + 1, 0, '', self.name)
-                        self.dcs.set_history_value(json.dumps(cluster.history.lines.append(new_state)))
-            else:  # no history yet, set initial item
-                self.dcs.set_history_value(json.dumps([(0, 0, '', self.name)]))  # FIXME: append to list instead
+                    if isinstance(history_state, list) and len(history_state) > 3:
+                        if history_state[3] != self.name:
+                            new_state = (history_state[0] + 1, 0, '', self.name)
+                            self.dcs.set_history_value(json.dumps(cluster.history.lines + [new_state]))
+                        return
+            # no history yet or broken history, set initial item
+            self.dcs.set_history_value(json.dumps([(0, 0, '', self.name)]))
 
     def _check_for_failover(self, cluster: Cluster):
         if cluster.failover and cluster.failover.target_site:

--- a/patroni/multisite.py
+++ b/patroni/multisite.py
@@ -373,7 +373,7 @@ class MultisiteController(Thread, AbstractSiteController):
                         return
                 else:
                     history_state = cluster.history.lines[-1]
-                    if isinstance(history_state, list) and len(history_state) > 3:
+                    if isinstance(history_state, (list, tuple)) and len(history_state) > 3:  # pyright: ignore[reportUnnecessaryIsInstance]
                         if history_state[3] != self.name:
                             new_state = (history_state[0] + 1, 0, '', self.name)
                             self.dcs.set_history_value(json.dumps(cluster.history.lines + [new_state]))


### PR DESCRIPTION
Add slots support for multisite. Slots need to be defined in local DCS config.

Example dynamic configuration:

```yaml
    sites:
      site1:
        slot: site1
      site2:
        slot: site2
```